### PR TITLE
Fix filtering records in backend

### DIFF
--- a/lib/assets/javascripts/bootstrap-autocomplete-input.js
+++ b/lib/assets/javascripts/bootstrap-autocomplete-input.js
@@ -19,7 +19,7 @@ function autocomplete_query(obj){
 
             // load data from remote server
             var fp = obj.data("func-params");
-            var p = [];
+            var p = {};
 
             if (fp){
                 p = window[fp]();


### PR DESCRIPTION
#  Problem:
The param is not passed to the controller action from JS.
So backend always returns all records. It does not filter records by param on SQL level.

The problem was introduced in this commit:
https://github.com/maxivak/boostrap_autocomplete_input/commit/334e207c26a4e238719d50f93503ec95985ac0e7

The autocomplete_query function uses jQuery.getJSON() function to fetch data
from the rails backend.
As specified in https://api.jquery.com/jquery.getjson/
params(data in jquery docs) format must be provided in: PlainObject or String.
Current implementation provides param as Array.
In result the param is not passed at all and backend does not perform filtering.

Described better in the issue:
https://github.com/maxivak/boostrap_autocomplete_input/issues/3

# Solution:
Use PlainObject instead of Array.